### PR TITLE
Change Ruby version to 2.6.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '2.6.3'
+ruby '2.6.1'
 
 gem 'rails', '~> 6.0.0'
 gem 'pg', '>= 0.18', '< 2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -308,7 +308,7 @@ DEPENDENCIES
   webpacker (~> 4.0)
 
 RUBY VERSION
-   ruby 2.6.3p62
+   ruby 2.6.1p33
 
 BUNDLED WITH
    2.0.2


### PR DESCRIPTION
Change Ruby version to 2.6.1
=======================
## PR content
- Change Ruby version from 2.6.3 to 2.6.1
- Set up Continuous Integration with Semaphore

## What have we learned?
- How to set up Semaphore
- Semaphore does not currently have full support for Ruby 2.6.3

## Screenshot
![Screenshot from 2019-10-09 15-39-15](https://user-images.githubusercontent.com/49253769/66486687-64070680-eaab-11e9-87ea-d7ca63591c06.png)
